### PR TITLE
Fixed docs for 'theme_color' config

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ Or install it yourself as:
     $ gem install jekyll-swiss
 
 ## Usage
-This theme comes in eight different color variations. The default is set to the black theme, to change to a different theme edit the config under `theme-color: black` to one of the following colors:
+This theme comes in eight different color variations. The default is set to the black theme, to change to a different theme edit the config under `theme_color: black` to one of the following colors:
 
 |  |  |
 | --- | --- |
-| `theme-color: black` | `theme-color: red` |
+| `theme_color: black` | `theme_color: red` |
 | <img width="330" alt="black" src="https://cloud.githubusercontent.com/assets/334891/18476835/8d70b330-7999-11e6-8c84-a558906d636e.png"> | <img width="330" alt="red" src="https://cloud.githubusercontent.com/assets/334891/18477185/c53af09a-799a-11e6-9354-b9bf1a7f1826.png"> |
-| `theme-color: white` | `theme-color: gray` |
+| `theme_color: white` | `theme_color: gray` |
 | <img width="330" alt="white" src="https://cloud.githubusercontent.com/assets/334891/18477206/d9dc55fc-799a-11e6-89f2-b4ae150caa80.png"> | <img width="330" alt="gray" src="https://cloud.githubusercontent.com/assets/334891/18477058/4e61700c-799a-11e6-80a0-805e57f2563e.png"> |
-| `theme-color: blue` | `theme-color: pink` |
+| `theme_color: blue` | `theme_color: pink` |
 | <img width="330" alt="blue" src="https://cloud.githubusercontent.com/assets/334891/18477240/f03646d2-799a-11e6-8895-25b37d3a1438.png"> | <img width="330" alt="pink" src="https://cloud.githubusercontent.com/assets/334891/18477252/fb2f5128-799a-11e6-8c8f-e79d9c1884b7.png"> |
-| `theme-color: orange` | `theme-color: yellow` |
+| `theme_color: orange` | `theme_color: yellow` |
 | <img width="330" alt="orange" src="https://cloud.githubusercontent.com/assets/334891/18477265/06e302bc-799b-11e6-970e-6461b2a89c57.png"> | <img width="330" alt="yellow" src="https://cloud.githubusercontent.com/assets/334891/18477278/117347aa-799b-11e6-83a8-f82341c143e0.png"> |
 
 ## Contributing


### PR DESCRIPTION
I noticed that the docs incorrectly referred to the `theme_color` as `theme-color`. Updated the README to fix the discrepancy.  