### PR TITLE
BUGFIX: README tells you to use "pink", it needs to be "magenta"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ This theme comes in eight different color variations. The default is set to the 
 | <img width="330" alt="black" src="https://cloud.githubusercontent.com/assets/334891/18476835/8d70b330-7999-11e6-8c84-a558906d636e.png"> | <img width="330" alt="red" src="https://cloud.githubusercontent.com/assets/334891/18477185/c53af09a-799a-11e6-9354-b9bf1a7f1826.png"> |
 | `theme_color: white` | `theme_color: gray` |
 | <img width="330" alt="white" src="https://cloud.githubusercontent.com/assets/334891/18477206/d9dc55fc-799a-11e6-89f2-b4ae150caa80.png"> | <img width="330" alt="gray" src="https://cloud.githubusercontent.com/assets/334891/18477058/4e61700c-799a-11e6-80a0-805e57f2563e.png"> |
-| `theme_color: blue` | `theme_color: pink` |
-| <img width="330" alt="blue" src="https://cloud.githubusercontent.com/assets/334891/18477240/f03646d2-799a-11e6-8895-25b37d3a1438.png"> | <img width="330" alt="pink" src="https://cloud.githubusercontent.com/assets/334891/18477252/fb2f5128-799a-11e6-8c8f-e79d9c1884b7.png"> |
+| `theme_color: blue` | `theme_color: magenta` |
+| <img width="330" alt="blue" src="https://cloud.githubusercontent.com/assets/334891/18477240/f03646d2-799a-11e6-8895-25b37d3a1438.png"> | <img width="330" alt="magenta" src="https://cloud.githubusercontent.com/assets/334891/18477252/fb2f5128-799a-11e6-8c8f-e79d9c1884b7.png"> |
 | `theme_color: orange` | `theme_color: yellow` |
 | <img width="330" alt="orange" src="https://cloud.githubusercontent.com/assets/334891/18477265/06e302bc-799b-11e6-970e-6461b2a89c57.png"> | <img width="330" alt="yellow" src="https://cloud.githubusercontent.com/assets/334891/18477278/117347aa-799b-11e6-83a8-f82341c143e0.png"> |
 


### PR DESCRIPTION
The README.md says that to use the "pink" theme you need to set `theme_color: pink` but the theme file in `_sass` is called `_theme-magenta.scss` so you need to set `theme_color: magenta` for it to work.

So I updated the README to fix that.