### PR TITLE
Update instructions for using Jekyll Remote Theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,35 +14,32 @@ Swiss is a bold Jekyll theme inspired by Swiss design and the works of Massimo V
 Add this line to your Jekyll site's Gemfile:
 
 ```ruby
-gem "jekyll-swiss"
+gem "github-pages", group: :jekyll_plugins
 ```
 
 And add this line to your Jekyll site:
 
 ```yaml
-theme: jekyll-swiss
+remote_theme: broccolini/swiss
 ```
 
 And then execute:
 
     $ bundle
 
-Or install it yourself as:
-
-    $ gem install jekyll-swiss
-
 ## Usage
+
 This theme comes in eight different color variations. The default is set to the black theme, to change to a different theme edit the config under `theme_color: black` to one of the following colors:
 
-|  |  |
-| --- | --- |
-| `theme_color: black` | `theme_color: red` |
-| <img width="330" alt="black" src="https://cloud.githubusercontent.com/assets/334891/18476835/8d70b330-7999-11e6-8c84-a558906d636e.png"> | <img width="330" alt="red" src="https://cloud.githubusercontent.com/assets/334891/18477185/c53af09a-799a-11e6-9354-b9bf1a7f1826.png"> |
-| `theme_color: white` | `theme_color: gray` |
-| <img width="330" alt="white" src="https://cloud.githubusercontent.com/assets/334891/18477206/d9dc55fc-799a-11e6-89f2-b4ae150caa80.png"> | <img width="330" alt="gray" src="https://cloud.githubusercontent.com/assets/334891/18477058/4e61700c-799a-11e6-80a0-805e57f2563e.png"> |
-| `theme_color: blue` | `theme_color: pink` |
-| <img width="330" alt="blue" src="https://cloud.githubusercontent.com/assets/334891/18477240/f03646d2-799a-11e6-8895-25b37d3a1438.png"> | <img width="330" alt="pink" src="https://cloud.githubusercontent.com/assets/334891/18477252/fb2f5128-799a-11e6-8c8f-e79d9c1884b7.png"> |
-| `theme_color: orange` | `theme_color: yellow` |
+|                                                                                                                                          |                                                                                                                                          |
+|:-----------------------------------------------------------------------------------------------------------------------------------------|:-----------------------------------------------------------------------------------------------------------------------------------------|
+| `theme_color: black`                                                                                                                     | `theme_color: red`                                                                                                                       |
+| <img width="330" alt="black" src="https://cloud.githubusercontent.com/assets/334891/18476835/8d70b330-7999-11e6-8c84-a558906d636e.png">  | <img width="330" alt="red" src="https://cloud.githubusercontent.com/assets/334891/18477185/c53af09a-799a-11e6-9354-b9bf1a7f1826.png">    |
+| `theme_color: white`                                                                                                                     | `theme_color: gray`                                                                                                                      |
+| <img width="330" alt="white" src="https://cloud.githubusercontent.com/assets/334891/18477206/d9dc55fc-799a-11e6-89f2-b4ae150caa80.png">  | <img width="330" alt="gray" src="https://cloud.githubusercontent.com/assets/334891/18477058/4e61700c-799a-11e6-80a0-805e57f2563e.png">   |
+| `theme_color: blue`                                                                                                                      | `theme_color: pink`                                                                                                                      |
+| <img width="330" alt="blue" src="https://cloud.githubusercontent.com/assets/334891/18477240/f03646d2-799a-11e6-8895-25b37d3a1438.png">   | <img width="330" alt="pink" src="https://cloud.githubusercontent.com/assets/334891/18477252/fb2f5128-799a-11e6-8c8f-e79d9c1884b7.png">   |
+| `theme_color: orange`                                                                                                                    | `theme_color: yellow`                                                                                                                    |
 | <img width="330" alt="orange" src="https://cloud.githubusercontent.com/assets/334891/18477265/06e302bc-799b-11e6-970e-6461b2a89c57.png"> | <img width="330" alt="yellow" src="https://cloud.githubusercontent.com/assets/334891/18477278/117347aa-799b-11e6-83a8-f82341c143e0.png"> |
 
 ## Contributing


### PR DESCRIPTION
Previously, although undocumented, the Swiss theme was distributed with the GitHub Pages Gem so users could use it on GitHub Pages. 

Since then, it is no long necessary to bundle the theme as a Gem so it can be used on GitHub Pages, and the version that's currently distributed is more than a year out of date.

Instead, users can simply add `remote_theme: broccolini/swiss` to their site's config (instead of `theme: jekyll-theme-swiss`), and Jekyll will pull down the latest version of of GitHub.