### PR TITLE
Fix category post previews

### DIFF
--- a/_includes/previous-next_has-categories.html
+++ b/_includes/previous-next_has-categories.html
@@ -24,7 +24,7 @@
   <a class="no-underline border-top-thin py-1 block" href="{{ prev_post.url | prepend: full_base_url }}">
     <span class="h5 bold text-accent">Previous</span>
     <p class="bold h3 link-primary mb-1">{{ prev_post.title }}</p>
-    <p>{{ page.previous.content | strip_html | truncatewords:20 }}</p>
+    <p>{{ prev_post.content | strip_html | truncatewords:20 }}</p>
   </a>
 </div>
 {% endif %}
@@ -33,7 +33,7 @@
   <a class="no-underline border-top-thin py-1 block" href="{{ next_post.url | prepend: full_base_url }}">
     <span class="h5 bold text-accent">Next</span>
     <p class="bold h3 link-primary mb-1">{{ next_post.title }}</p>
-    <p>{{ page.next.content | strip_html | truncatewords:20 }}</p>
+    <p>{{ next_post.content | strip_html | truncatewords:20 }}</p>
   </a>
 </div>
 {% endif %}


### PR DESCRIPTION
Category posts currently display the content of the previous/next post regardless of whether they are in the same category. Small edit from page.prev and page.next to prev_post and next_post.