### PR TITLE
Prevent markdown link showing in next post excerpts

### DIFF
--- a/_includes/previous-next.html
+++ b/_includes/previous-next.html
@@ -15,7 +15,7 @@
     <a class="no-underline border-top-thin py-1 block" href="{{ page.next.url | prepend: full_base_url }}">
       <span class="h5 bold text-accent">Next</span>
       <p class="bold h3 link-primary mb-1">{{ page.next.title }}</p>
-      <p>{{ page.next.content | strip_html | truncatewords:20 }}</p>
+      <p>{{ page.next.content | markdownify | strip_html | truncatewords:20 }}</p>
     </a>
   </div>
 {% endif %}

--- a/_includes/previous-next_has-categories.html
+++ b/_includes/previous-next_has-categories.html
@@ -33,7 +33,7 @@
   <a class="no-underline border-top-thin py-1 block" href="{{ next_post.url | prepend: full_base_url }}">
     <span class="h5 bold text-accent">Next</span>
     <p class="bold h3 link-primary mb-1">{{ next_post.title }}</p>
-    <p>{{ page.next.content | strip_html | truncatewords:20 }}</p>
+    <p>{{ page.next.content | markdownify | strip_html | truncatewords:20 }}</p>
   </a>
 </div>
 {% endif %}


### PR DESCRIPTION
I noticed a small bug in the excerpt part of the next post link under the body of a post. If I add a markdown link at the very beginning of the article, then the markdown appears in the excerpt:

Here it is with the category-post layout:
<img width="398" alt="screenshot1" src="https://user-images.githubusercontent.com/74184770/208317677-8b1c327e-c2ca-426d-a3db-814f8c3c3cbd.png">

It also happens with the post layout:
<img width="317" alt="screenshot2" src="https://user-images.githubusercontent.com/74184770/208317725-54644176-78ab-4493-b202-d31fab910bf7.png">

Interestingly, it does not happen with the previous post part. Anyway, I found that using `markdownify,` just before `strip_html` solved the issue.