### PR TITLE
Remove protocol to resolve to https automatically from the browser

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,7 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
   {% assign user_url = site.url | append: site.baseurl %}
-  {% assign full_base_url = user_url | default: site.github.url %}
+  {% assign full_base_url = user_url | default: site.github.url | replace: 'http://', '//' %}
   <link rel="stylesheet" href="{{ "/assets/style.css" | prepend: full_base_url }}">
 
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">

--- a/_includes/previous-next.html
+++ b/_includes/previous-next.html
@@ -1,6 +1,6 @@
 <!-- Use if you want to show previous and next for all posts. -->
 {% assign user_url = site.url | append: site.baseurl %}
-{% assign full_base_url = user_url | default: site.github.url %}
+{% assign full_base_url = user_url | default: site.github.url | replace: 'http://', '//' %}
 {% if page.previous.url %}
   <div class="col-4 sm-width-full left mr-lg-4 mt-3">
     <a class="no-underline border-top-thin py-1 block" href="{{ page.previous.url | prepend: full_base_url }}">

--- a/_includes/previous-next_has-categories.html
+++ b/_includes/previous-next_has-categories.html
@@ -18,7 +18,7 @@
   {% endfor %}
 {% endif %}
 {% assign user_url = site.url | append: site.baseurl %}
-{% assign full_base_url = user_url | default: site.github.url %}
+{% assign full_base_url = user_url | default: site.github.url | replace: 'http://', '//'  %}
 {% if prev_post %}
 <div class="col-4 sm-width-full left mr-lg-4 mt-3">
   <a class="no-underline border-top-thin py-1 block" href="{{ prev_post.url | prepend: full_base_url }}">


### PR DESCRIPTION
TL;DR the styles won't load if serving via HTTPS when loading URL from site.github.url

We are using this template at https://github.com/JConfMexico/jalapenio/blob/cbc700b1d3fe285a761510c5fae7036aafaa22bf/_config.yml#L15

Noticed that the CSS styles break after we enable HTTPS to Github Pages. This is a common [mixed content error documented by Github](https://docs.github.com/en/pages/getting-started-with-github-pages/securing-your-github-pages-site-with-https#resolving-problems-with-mixed-content).

This appears to be a [common issue on Github pages](https://github.com/github/pages-gem/issues/238) when using the scriptlet `default: site.github.url`. Applied the general pattern discussed there to allow the browser to self-resolve the protocol.